### PR TITLE
feat: add menu-overlay helpers

### DIFF
--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -1,9 +1,41 @@
+// Utility menu overlay functions
 import type {
   MenuOverlayItem,
   MenuOverlayStrings,
 } from '@ircsignpost/signpost-base/dist/src/menu-overlay';
+import { ZendeskCategory } from '@ircsignpost/signpost-base/dist/src/zendesk';
 
-// TODO Update menu items.
-export function getMenuItems(strings: MenuOverlayStrings): MenuOverlayItem[] {
-  return [{ key: 'home', label: strings.home, href: '/' }];
+import { ABOUT_US_ARTICLE_ID } from './constants';
+
+export interface CustomMenuOverlayStrings extends MenuOverlayStrings {
+  information: string;
+  about: string;
+}
+
+// TODO Update menu items if needed.
+export function getMenuItems(
+  strings: CustomMenuOverlayStrings,
+  categories: ZendeskCategory[]
+): MenuOverlayItem[] {
+  let items: MenuOverlayItem[] = [];
+  items.push({ key: 'home', label: strings.home, href: '/' });
+  if (categories.length > 0) {
+    items.push({
+      key: 'information',
+      label: strings.information,
+      children: categories.map((category) => {
+        return {
+          key: category.id.toString(),
+          label: category.name,
+          href: '/categories/' + category.id.toString(),
+        };
+      }),
+    });
+  }
+  items.push({
+    key: 'about',
+    label: strings.about,
+    href: `/articles/${ABOUT_US_ARTICLE_ID}`,
+  });
+  return items;
 }

--- a/lib/translations.tsx
+++ b/lib/translations.tsx
@@ -5,12 +5,14 @@ import { ShareButtonProps } from '@ircsignpost/signpost-base/dist/src/share-butt
 import { CardsListStrings } from '@ircsignpost/signpost-base/dist/src/home-page-cards-list';
 import { CookieBannerStrings } from '@ircsignpost/signpost-base/dist/src/cookie-banner';
 import { HomePageStrings } from '@ircsignpost/signpost-base/dist/src/home-page';
-import { MenuOverlayStrings } from '@ircsignpost/signpost-base/dist/src/menu-overlay';
+import { CustomMenuOverlayStrings } from './menu';
 
 /** General strings used on various pages. */
 export const COMMON_DYNAMIC_CONTENT_PLACEHOLDERS = [
   // Header strings.
   'default_menu_home_title',
+  'default_information_title',
+  'default_menu_about_title',
   // Cookie banner strings.
   'default_cookie_banner',
   'default_accept',
@@ -154,9 +156,11 @@ export function getSelectTopicLabel(dynamicContent: {
 
 export function populateMenuOverlayStrings(dynamicContent: {
   [key: string]: string;
-}): MenuOverlayStrings {
+}): CustomMenuOverlayStrings {
   return {
     home: dynamicContent['default_menu_home_title'],
+    information: dynamicContent['default_information_title'],
+    about: dynamicContent['default_menu_about_title'],
   };
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -90,7 +90,8 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   categories.forEach((c) => (c.icon = CATEGORY_ICON_NAMES[c.id]));
 
   const menuOverlayItems = getMenuItems(
-    populateMenuOverlayStrings(dynamicContent)
+    populateMenuOverlayStrings(dynamicContent),
+    categories
   );
   const article = await getArticle(
     currentLocale,


### PR DESCRIPTION
Created helpers to use menu on every page. Simply need to call the following and pass the variable to the page.
```
const menuOverlayItems = getCustomMenuItems(
  populateMenuOverlayStrings(dynamicContent),
  categories
);
```