### PR TITLE
fix(cypress): wait for localhost

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,3 +13,4 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           start: yarn dev --port 3003
+          wait-on: http://localhost:3003


### PR DESCRIPTION
Wait for localhost to become responsive before running tests. This should fix problems with the initial test timing out.