### PR TITLE
fix(sitemap): exclude categories

### DIFF
--- a/next-sitemap.config.mjs
+++ b/next-sitemap.config.mjs
@@ -12,7 +12,7 @@ function getSiteUrl() {
 const config = {
   siteUrl: getSiteUrl(),
   generateRobotsTxt: true,
-  exclude: ['/server-sitemap.xml'],
+  exclude: ['/*/categories/*', '/server-sitemap.xml'],
   robotsTxtOptions: {
     additionalSitemaps: [getSiteUrl() + '/server-sitemap.xml'],
   },

--- a/pages/server-sitemap.xml/index.tsx
+++ b/pages/server-sitemap.xml/index.tsx
@@ -10,7 +10,7 @@ export async function getServerSideProps(
   ctx: GetServerSidePropsContext<ParsedUrlQuery, PreviewData>
 ) {
   const allPaths: string[] = await Promise.all([
-    /* Put dynamic paths here */
+    /* Put dynamic paths here and exclude them from next-sitemap.config.mjs */
     category.getStringPaths(),
   ]).then((results: string[][]) => results.flat());
 


### PR DESCRIPTION
Don't put categories in the static sitemap, because they are already covered by the server-side generated sitemap.