### PR TITLE
fix: use getStaticPaths to block categories

### DIFF
--- a/pages/categories/[category].tsx
+++ b/pages/categories/[category].tsx
@@ -101,6 +101,16 @@ async function getStaticParams() {
 }
 
 export async function getStaticPaths() {
+  if (USE_CAT_SEC_ART_CONTENT_STRUCTURE) {
+    // Category page does not exist in this type of content structure.
+    // All paths under categories should return 404
+    // (https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#fallback-false).
+    return {
+      paths: [],
+      fallback: false,
+    };
+  }
+
   const categoryParams = await getStaticParams();
 
   return {
@@ -119,15 +129,15 @@ function getStringPath(category: string, locale: string): string {
 }
 
 export async function getStringPaths(): Promise<string[]> {
+  if (USE_CAT_SEC_ART_CONTENT_STRUCTURE) {
+    // Category page does not exist in this type of content structure.
+    return [];
+  }
   const params = await getStaticParams();
   return params.map((param) => getStringPath(param.category, param.locale));
 }
 
 export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
-  // Category page does not exist in this type of content structure.
-  if (USE_CAT_SEC_ART_CONTENT_STRUCTURE) {
-    return { notFound: true, props: {} };
-  }
   if (!locale) {
     throw new Error(
       `Failed to get static props for a category (id: ${params?.category}): missing locale.`


### PR DESCRIPTION
Relevant for https://github.com/unitedforukraine/signpost-template/issues/105.

Using getStaticProps to return notFound was wrong, because:

1. It didn't prevent the sitemap from falsely generating paths to categories.
2. It was less efficient as our site would run a render on calls to those paths.