### PR TITLE
fix: dont show about in header menu if it does not exist

### DIFF
--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -21,7 +21,8 @@ export interface CustomMenuOverlayStrings extends MenuOverlayStrings {
 // TODO Update menu items if needed.
 export function getMenuItems(
   strings: CustomMenuOverlayStrings,
-  categories: ZendeskCategory[] | CategoryWithSections[]
+  categories: ZendeskCategory[] | CategoryWithSections[],
+  includeAbout: boolean
 ): MenuOverlayItem[] {
   let items: MenuOverlayItem[] = [];
   items.push({ key: 'home', label: strings.home, href: '/' });
@@ -30,11 +31,13 @@ export function getMenuItems(
   } else {
     addMenuItemsInformation(items, strings, categories as ZendeskCategory[]);
   }
-  items.push({
-    key: 'about',
-    label: strings.about,
-    href: `/articles/${ABOUT_US_ARTICLE_ID}`,
-  });
+  if (includeAbout) {
+    items.push({
+      key: 'about',
+      label: strings.about,
+      href: `/articles/${ABOUT_US_ARTICLE_ID}`,
+    });
+  }
   return items;
 }
 

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -11,6 +11,7 @@ import { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 
 import {
+  ABOUT_US_ARTICLE_ID,
   CATEGORIES_TO_HIDE,
   CATEGORY_ICON_NAMES,
   GOOGLE_ANALYTICS_IDS,
@@ -35,9 +36,10 @@ import {
   populateCustom404Strings,
   populateMenuOverlayStrings,
 } from '../lib/translations';
-import { getZendeskUrl } from '../lib/url';
+import { getZendeskMappedUrl, getZendeskUrl } from '../lib/url';
 // TODO Use real Zendesk API implementation.
 import {
+  getArticle,
   getCategories,
   getCategoriesWithSections,
   getTranslationsFromDynamicContent,
@@ -112,9 +114,18 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       (c) => (c.icon = CATEGORY_ICON_NAMES[c.id] || 'help_outline')
     );
   }
+
+  const aboutUsArticle = await getArticle(
+    currentLocale,
+    ABOUT_US_ARTICLE_ID,
+    getZendeskUrl(),
+    getZendeskMappedUrl(),
+    ZENDESK_AUTH_HEADER
+  );
   const menuOverlayItems = getMenuItems(
     populateMenuOverlayStrings(dynamicContent),
-    categories
+    categories,
+    !!aboutUsArticle
   );
 
   return {

--- a/pages/articles/[article].tsx
+++ b/pages/articles/[article].tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'next/router';
 import React from 'react';
 
 import {
+  ABOUT_US_ARTICLE_ID,
   CATEGORIES_TO_HIDE,
   CATEGORY_ICON_NAMES,
   GOOGLE_ANALYTICS_IDS,
@@ -210,9 +211,17 @@ export const getStaticProps: GetStaticProps = async ({
       (c) => (c.icon = CATEGORY_ICON_NAMES[c.id] || 'help_outline')
     );
   }
+  const aboutUsArticle = await getArticle(
+    currentLocale,
+    ABOUT_US_ARTICLE_ID,
+    getZendeskUrl(),
+    getZendeskMappedUrl(),
+    ZENDESK_AUTH_HEADER
+  );
   const menuOverlayItems = getMenuItems(
     populateMenuOverlayStrings(dynamicContent),
-    categories
+    categories,
+    !!aboutUsArticle
   );
 
   const strings = populateArticlePageStrings(dynamicContent);

--- a/pages/categories/[category].tsx
+++ b/pages/categories/[category].tsx
@@ -9,6 +9,7 @@ import { Section } from '@ircsignpost/signpost-base/dist/src/topic-with-articles
 import { GetStaticProps } from 'next';
 
 import {
+  ABOUT_US_ARTICLE_ID,
   CATEGORIES_TO_HIDE,
   CATEGORY_ICON_NAMES,
   GOOGLE_ANALYTICS_IDS,
@@ -33,9 +34,10 @@ import {
   populateCategoryStrings,
   populateMenuOverlayStrings,
 } from '../../lib/translations';
-import { getZendeskUrl } from '../../lib/url';
+import { getZendeskMappedUrl, getZendeskUrl } from '../../lib/url';
 // TODO Use real Zendesk API implementation.
 import {
+  getArticle,
   getCategories,
   getSectionsForCategory,
   getTranslationsFromDynamicContent,
@@ -164,9 +166,18 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
     };
   });
 
+  const aboutUsArticle = await getArticle(
+    currentLocale,
+    ABOUT_US_ARTICLE_ID,
+    getZendeskUrl(),
+    getZendeskMappedUrl(),
+    ZENDESK_AUTH_HEADER
+  );
+
   const menuOverlayItems = getMenuItems(
     populateMenuOverlayStrings(dynamicContent),
-    categories
+    categories,
+    !!aboutUsArticle
   );
 
   // TODO Use real Zendesk API instead of the faked one.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -138,18 +138,20 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
     );
   }
 
-  const menuOverlayItems = getMenuItems(
-    populateMenuOverlayStrings(dynamicContent),
-    categories
-  );
-  const article = await getArticle(
+  const aboutUsArticle = await getArticle(
     currentLocale,
     ABOUT_US_ARTICLE_ID,
     getZendeskUrl(),
     getZendeskMappedUrl(),
     ZENDESK_AUTH_HEADER
   );
-  const aboutUsTextHtml = article ? article.body : '';
+  const aboutUsTextHtml = aboutUsArticle ? aboutUsArticle.body : '';
+
+  const menuOverlayItems = getMenuItems(
+    populateMenuOverlayStrings(dynamicContent),
+    categories,
+    !!aboutUsArticle
+  );
 
   const strings = populateHomePageStrings(dynamicContent);
 

--- a/pages/search-results-page.tsx
+++ b/pages/search-results-page.tsx
@@ -11,6 +11,7 @@ import {
 import { GetStaticProps } from 'next';
 
 import {
+  ABOUT_US_ARTICLE_ID,
   CATEGORIES_TO_HIDE,
   CATEGORY_ICON_NAMES,
   GOOGLE_ANALYTICS_IDS,
@@ -36,9 +37,10 @@ import {
   populateMenuOverlayStrings,
   populateSearchResultsPageStrings,
 } from '../lib/translations';
-import { getZendeskUrl } from '../lib/url';
+import { getZendeskMappedUrl, getZendeskUrl } from '../lib/url';
 // TODO: import methods from '@ircsignpost/signpost-base/dist/src/zendesk' instead.
 import {
+  getArticle,
   getCategories,
   getCategoriesWithSections,
   getTranslationsFromDynamicContent,
@@ -110,9 +112,18 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
     );
   }
 
+  const aboutUsArticle = await getArticle(
+    currentLocale,
+    ABOUT_US_ARTICLE_ID,
+    getZendeskUrl(),
+    getZendeskMappedUrl(),
+    ZENDESK_AUTH_HEADER
+  );
+
   const menuOverlayItems = getMenuItems(
     populateMenuOverlayStrings(dynamicContent),
-    categories
+    categories,
+    !!aboutUsArticle
   );
 
   const strings = populateSearchResultsPageStrings(dynamicContent);

--- a/pages/sections/[section].tsx
+++ b/pages/sections/[section].tsx
@@ -12,6 +12,7 @@ import {
 import { GetStaticProps } from 'next';
 
 import {
+  ABOUT_US_ARTICLE_ID,
   CATEGORIES_TO_HIDE,
   GOOGLE_ANALYTICS_IDS,
   REVALIDATION_TIMEOUT_SECONDS,
@@ -36,9 +37,10 @@ import {
   populateMenuOverlayStrings,
   populateSectionStrings,
 } from '../../lib/translations';
-import { getZendeskUrl } from '../../lib/url';
+import { getZendeskMappedUrl, getZendeskUrl } from '../../lib/url';
 // TODO Use real Zendesk API implementation.
 import {
+  getArticle,
   getArticlesForSection,
   getCategoriesWithSections,
   getSection,
@@ -220,9 +222,18 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
       };
     });
 
+  const aboutUsArticle = await getArticle(
+    currentLocale,
+    ABOUT_US_ARTICLE_ID,
+    getZendeskUrl(),
+    getZendeskMappedUrl(),
+    ZENDESK_AUTH_HEADER
+  );
+
   const menuOverlayItems = getMenuItems(
     populateMenuOverlayStrings(dynamicContent),
-    categories
+    categories,
+    !!aboutUsArticle
   );
 
   return {


### PR DESCRIPTION
Fix for https://github.com/unitedforukraine/signpost-base/issues/260.
The sites (or in this case template), not the signpost-base components, should determine what is shown in the header.